### PR TITLE
Move line that logs record to be outside of a loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,9 @@ function setEventNames(sqsConfig) {
 async function sendToSqs({ record, params }) {
   const MessageBody = JSON.stringify(params.bodyHandler(record));
 
-  const promises = params.sqsConfigs.map(sqsConfig => {
-    params.logger.info('DynamoDB Record: %j', record);
+  params.logger.info('DynamoDB Record: %j', record);
 
+  const promises = params.sqsConfigs.map(sqsConfig => {
     const body = {
       MessageBody,
       QueueUrl: sqsConfig.endpoint,


### PR DESCRIPTION
This avoids producing multiple identical logs when sending to sqs

![duplicates](https://media.giphy.com/media/ToMjGpmGUC7axrjBAmQ/giphy.gif)