### PR TITLE
Add a 5s connect timeout for sqs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const AWS = require('aws-sdk');
-Aws.config.update({
+AWS.config.update({
   region: process.env.AWS_REGION || 'us-east-1',
   sqs: { apiVersion: '2012-11-05' },
   httpOptions: { connectTimeout: 5000 },

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 const assert = require('assert');
 const AWS = require('aws-sdk');
+Aws.config.update({
+  region: process.env.AWS_REGION || 'us-east-1',
+  sqs: { apiVersion: '2012-11-05' },
+  httpOptions: { connectTimeout: 5000 },
+});
 
 const sqs = new AWS.SQS();
 


### PR DESCRIPTION
```
connectTimeout [Integer] — 
Sets the socket to timeout after failing to establish a connection 
  with the server after connectTimeout milliseconds. 
This timeout has no effect once a socket connection has been established.
```

![](https://laughingsquid.com/wp-content/uploads/2014/02/Wcwf8Dg.gif)