### PR TITLE
Filter Messages on a Per SQS_CONFIG basis

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,11 +64,6 @@ async function sendToSqs({ record, params }) {
 
   params.logger.info('DynamoDB Record: %j', record);
 
-  if (!params.messageFilter(message)) {
-    params.logger.info('DynamoDB message filtered from SQS: %j', message);
-    return;
-  }
-
   const promises = params.sqsConfigs.map(sqsConfig => {
     const body = {
       MessageBody,
@@ -77,6 +72,11 @@ async function sendToSqs({ record, params }) {
 
     if (!sqsConfig.eventNames.includes(record.eventName.toUpperCase())) {
       params.logger.info(`Event not forwarded to SQS ${sqsConfig.endpoint}: Event Name ${record.eventName}`);
+      return;
+    }
+
+    if (!params.messageFilter({ ...message, sqsConfig })) {
+      params.logger.info(`DynamoDB message (${message}) filtered from SQS (${sqsConfig})`);
       return;
     }
 


### PR DESCRIPTION
What Do
---
- Filter messages on a per-sqs-config basis, thereby letting you send a subset of messages to any specific sqs queue
  - The SQS config being process is now sent along to the message filter along with the message itself. 


![](https://media.architecturaldigest.com/photos/5c94f47d6b6fbc0dae4dd31c/master/pass/water-filters.gif)