### PR TITLE
Add ability to transform (generally shrink) logs before logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const assert = require('assert');
 const { SQS } = require('@aws-sdk/client-sqs');
 const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
@@ -61,7 +60,7 @@ function setEventNames(sqsConfig) {
   );
 }
 
-async function sendToSqs({ record, params, logPayloadTransformer = _.identity }) {
+async function sendToSqs({ record, params, logPayloadTransformer = (record) => record }) {
   const message = params.bodyHandler(record);
   const MessageBody = JSON.stringify(message);
 
@@ -69,6 +68,7 @@ async function sendToSqs({ record, params, logPayloadTransformer = _.identity })
     params.logger.info('DynamoDB Record: %j', logPayloadTransformer(record));
   } catch (err) {
     params.logger.error({ err }, 'Error logging DynamoDB record');
+    params.logger.info('DynamoDB Record: %j', record);
   }
 
   const promises = params.sqsConfigs.map(sqsConfig => {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const assert = require('assert');
 const { SQS } = require('@aws-sdk/client-sqs');
 const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
@@ -15,7 +16,7 @@ const RAW_BODY_HANDLER = record => record;
 const NO_FILTER = () => true;
 
 class DynamoStreamHandler {
-  constructor({ sqsConfigs, logger, customBodyHandler, messageFilter } = {}) {
+  constructor({ sqsConfigs, logger, customBodyHandler, messageFilter, logPayloadTransformer } = {}) {
     assert(
       sqsConfigs && Array.isArray(sqsConfigs) && sqsConfigs.length > 0,
       'sqsConfig must be an array with at least one element',
@@ -39,7 +40,7 @@ class DynamoStreamHandler {
 
     this.handler = async (event, context) => {
       try {
-        const promises = event.Records.map(record => sendToSqs({ record, params }));
+        const promises = event.Records.map(record => sendToSqs({ record, params, logPayloadTransformer }));
         await Promise.all(promises);
 
         return `Successfully processed ${event.Records.length} records.`;
@@ -60,11 +61,11 @@ function setEventNames(sqsConfig) {
   );
 }
 
-async function sendToSqs({ record, params }) {
+async function sendToSqs({ record, params, logPayloadTransformer = _.identity }) {
   const message = params.bodyHandler(record);
   const MessageBody = JSON.stringify(message);
 
-  params.logger.info('DynamoDB Record: %j', record);
+  params.logger.info('DynamoDB Record: %j', logPayloadTransformer(record));
 
   const promises = params.sqsConfigs.map(sqsConfig => {
     const body = {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,11 @@ async function sendToSqs({ record, params, logPayloadTransformer = _.identity })
   const message = params.bodyHandler(record);
   const MessageBody = JSON.stringify(message);
 
-  params.logger.info('DynamoDB Record: %j', logPayloadTransformer(record));
+  try {
+    params.logger.info('DynamoDB Record: %j', logPayloadTransformer(record));
+  } catch (err) {
+    params.logger.error({ err }, 'Error logging DynamoDB record');
+  }
 
   const promises = params.sqsConfigs.map(sqsConfig => {
     const body = {


### PR DESCRIPTION
Add support for transforming logs before we log the Dynamo record so that we can remove some verbose/large parts of log messages (specifically forecasts)

See https://github.com/BinSentry/api/pull/2714 for how this will be used in API

![transformer](https://github.com/user-attachments/assets/0e5659d8-053e-4a96-8127-6021c05b42af)
